### PR TITLE
Add a 'printVersion' task to the plugin

### DIFF
--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionPlugin.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 import com.palantir.gradle.versions.flexversioning.FlexVersionExtension;
+import com.palantir.gradle.versions.flexversioning.PrintVersionTask;
 
 class FlexVersionPlugin implements Plugin<Project> {
 
@@ -46,9 +47,11 @@ class FlexVersionPlugin implements Plugin<Project> {
         FlexVersionConvention convention = new FlexVersionConvention(project, extension);
         project.getConvention().getPlugins().put("flexversion", convention);
         project.getExtensions().add("flexversion", extension);
+
+        project.getTasks().create("printVersion", PrintVersionTask.class);
     }
 
-    public static String buildFlexVersion(Project project, String userDomain, FlexVersionExtension flexExtension) {
+    static String buildFlexVersion(Project project, String userDomain, FlexVersionExtension flexExtension) {
         Repository repo = getRepo(project);
 
         RevWalk walk = new RevWalk(repo);

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/PrintVersionTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/PrintVersionTask.groovy
@@ -1,0 +1,17 @@
+package com.palantir.gradle.versions.flexversioning
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.tasks.TaskAction;
+
+class PrintVersionTask extends DefaultTask {
+
+    public PrintVersionTask() {
+        setDescription("Print the version of the project.")
+    }
+
+    @TaskAction
+    public void printVersion() {
+        getProject().getLogger().log(LogLevel.QUIET, getProject().getVersion())
+    }
+}


### PR DESCRIPTION
-It logs at the QUIET level so --quiet still lets the value show
