### PR TITLE
Return a FlexVersion object instead of a String.

### DIFF
--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersion.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersion.groovy
@@ -15,21 +15,35 @@ package com.palantir.gradle.versions.flexversioning
 
 class FlexVersion {
     String domain = null;
-    String commitCount = null;
     String gitHash = null;
     String fullVersion = null;
+
+    int commitCount = -1;
 
     boolean dirty = false;
     boolean tag = false;
 
-    public FlexVersion (String domain, String commitCount, String gitHash, boolean dirty) {
+    public FlexVersion (String domain, int commitCount, String gitHash, boolean tag, boolean dirty) {
         this.domain = domain;
         this.commitCount = commitCount;
         this.gitHash = gitHash;
+        this.tag = tag;
         this.dirty = dirty;
+
+        String dirtyBit = this.dirty ? "-dirty" : "";
+
+        if (this.tag) {
+            this.fullVersion = "${this.domain}${dirtyBit}"
+        } else {
+            this.fullVersion = "${this.domain}-${this.commitCount}-g${this.gitHash.substring(0,12)}${dirty}";
+        }
     }
 
     public String toString() {
         return this.fullVersion;
+    }
+
+    public String shortGitHash() {
+        return this.gitHash.substring(0,12);
     }
 }

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersion.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersion.groovy
@@ -30,20 +30,22 @@ class FlexVersion {
         this.tag = tag;
         this.dirty = dirty;
 
-        String dirtyBit = this.dirty ? "-dirty" : "";
+        if (this.gitHash.length() > 12) {
+            this.gitHash = this.gitHash.substring(0, 12);
+        }
 
         if (this.tag) {
-            this.fullVersion = "${this.domain}${dirtyBit}"
+            this.fullVersion = "${this.domain}"
         } else {
-            this.fullVersion = "${this.domain}-${this.commitCount}-g${this.gitHash.substring(0,12)}${dirty}";
+            this.fullVersion = "${this.domain}-${this.commitCount}-g${this.gitHash}";
+        }
+
+        if (this.dirty) {
+            this.fullVersion = "${this.fullVersion}-dirty";
         }
     }
 
     public String toString() {
         return this.fullVersion;
-    }
-
-    public String shortGitHash() {
-        return this.gitHash.substring(0,12);
     }
 }

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersion.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersion.groovy
@@ -1,0 +1,35 @@
+// Copyright 2015 Palantir Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.palantir.gradle.versions.flexversioning
+
+class FlexVersion {
+    String domain = null;
+    String commitCount = null;
+    String gitHash = null;
+    String fullVersion = null;
+
+    boolean dirty = false;
+    boolean tag = false;
+
+    public FlexVersion (String domain, String commitCount, String gitHash, boolean dirty) {
+        this.domain = domain;
+        this.commitCount = commitCount;
+        this.gitHash = gitHash;
+        this.dirty = dirty;
+    }
+
+    public String toString() {
+        return this.fullVersion;
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionConvention.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionConvention.groovy
@@ -25,11 +25,11 @@ public class FlexVersionConvention {
         this.extension = extension;
     }
 
-    public String flexVersion() {
+    public FlexVersion flexVersion() {
         return FlexVersionPlugin.buildFlexVersion(project, null, extension);
     }
 
-    public String flexVersion(String userDomain) {
+    public FlexVersion flexVersion(String userDomain) {
         return FlexVersionPlugin.buildFlexVersion(project, userDomain, extension);
     }
 }

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionPlugin.groovy
@@ -71,7 +71,7 @@ class FlexVersionPlugin implements Plugin<Project> {
 
 
         // Count commits
-        String commitCount = RevWalkUtils.count(walk, headCommit, firstCommit).toString();
+        int commitCount = RevWalkUtils.count(walk, headCommit, firstCommit);
 
 
         // Find if there is a tag on the HEAD commit.
@@ -144,16 +144,7 @@ class FlexVersionPlugin implements Plugin<Project> {
             }
         }
 
-        FlexVersion version = new FlexVersion(domain, commitCount, headSha1.substring(0,12), isDirty);
-
-        if (tag) {
-            version.tag = true;
-            version.fullVersion = "${domain}${dirty}";
-        } else {
-            version.fullVersion = "${domain}-${commitCount}-g${headSha1.substring(0,12)}${dirty}";
-        }
-
-        return version
+        return new FlexVersion(domain, commitCount, headSha1, isDirty, tag);
     }
 
     private static Repository getRepo(Project project) {

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/PrintVersionTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/PrintVersionTask.groovy
@@ -12,6 +12,6 @@ class PrintVersionTask extends DefaultTask {
 
     @TaskAction
     public void printVersion() {
-        getProject().getLogger().log(LogLevel.QUIET, getProject().getVersion())
+        getProject().getLogger().log(LogLevel.QUIET, getProject().getVersion().toString())
     }
 }


### PR DESCRIPTION
-This will allow a user to extract information from the version w/o needing to parse
-Gradle is smart enough to take an Object for a version so this will work as it calls toString
-Anything expecting an actual String will fail and need to change to have a toString()
