### PR TITLE
Add support for symlinks in repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'org.eclipse.jgit:org.eclipse.jgit:3.4.1.201406201815-r'
+  compile 'org.eclipse.jgit:org.eclipse.jgit.java7:3.4.1.201406201815-r'
 }
 
 apply plugin: 'gradle-flexversion'


### PR DESCRIPTION
JGit's core jar doesn't support symlinks, because that requires Java
7. This change adds in the extra org.eclipse.jgit.java7 dependency so
that the Gradle plugin works correctly when symlinks are checked into
the repository.

(The core jar is included transitively now.)
