### PR TITLE
Commits seemed to be counted wrong.  Fix the possible off-by-one

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@ CHANGELOG
 
 Future Version
 =======
-
+-Breaking (Possibly): Changed the commit count logic to use null as the end commit. This should give a better count
+    * Older built versions' count # in a non tag version may be different now
 
 0.7.0
 =======

--- a/src/main/groovy/com/palantir/gradle/versions/flexversioning/GitUtils.groovy
+++ b/src/main/groovy/com/palantir/gradle/versions/flexversioning/GitUtils.groovy
@@ -13,24 +13,17 @@
 // limitations under the License.
 package com.palantir.gradle.versions.flexversioning
 
-import groovy.transform.PackageScope;
-
-import java.nio.file.Paths;
-
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.errors.RepositoryNotFoundException;
-import org.eclipse.jgit.lib.AnyObjectId;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.RepositoryCache;
-import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevSort;
-import org.eclipse.jgit.revwalk.RevWalk;
-import org.eclipse.jgit.revwalk.RevWalkUtils;
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.errors.RepositoryNotFoundException
+import org.eclipse.jgit.lib.AnyObjectId
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevCommit
+import org.eclipse.jgit.revwalk.RevWalk
+import org.eclipse.jgit.revwalk.RevWalkUtils
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.eclipse.jgit.util.FS;
 import org.gradle.api.GradleException
-import org.gradle.api.Project;
+import org.gradle.api.Project
 
 class GitUtils {
 
@@ -73,10 +66,7 @@ class GitUtils {
      */
     static int countCommitHistory(Repository repo, RevCommit commit) {
         RevWalk walk = new RevWalk(repo);
-        walk.sort(RevSort.REVERSE);
-        walk.markStart(commit);
-        RevCommit firstCommit = walk.next();
-        return RevWalkUtils.count(walk, commit, firstCommit);
+        return RevWalkUtils.count(walk, commit, null);
     }
 
 

--- a/src/test/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/flexversioning/FlexVersionTests.groovy
@@ -1,22 +1,19 @@
 package com.palantir.gradle.versions.flexversioning
 
-import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.internal.storage.file.FileRepository
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Ignore
+import org.junit.Test
 
-import com.palantir.gradle.versions.flexversioning.FlexVersionPlugin.FlexVersionPatternException;
-import com.sun.org.apache.xalan.internal.xsltc.cmdline.getopt.IllegalArgumentException;
+import com.palantir.gradle.versions.flexversioning.FlexVersionPlugin.FlexVersionPatternException
 
 class FlexVersionTests {
 
@@ -54,7 +51,6 @@ class FlexVersionTests {
             git.commit().setMessage(message).call();
             commits++;
         }
-        commits--; // The HEAD commit is not counted
 
         RevCommit head = new RevWalk(repo).parseCommit(repo.resolve(Constants.HEAD));
         headShaShort = head.name().substring(0,12);


### PR DESCRIPTION
- There were a few cases of the logic being off by one and not matching 'git rev-list --count hEAD'
- Setting it to null means count until there are no more commits
